### PR TITLE
Change module name

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'lame' {
+declare module '@suldashi/lame' {
     import { WriteStream } from 'fs';
     import { DuplexOptions } from 'stream';
 


### PR DESCRIPTION
As this package is published as `@suldashi/lame`, declaring the module name as `lame` gives a TS error when importing the module:
```
error TS2306: File 'node_modules/@suldashi/lame/index.d.ts' is not a module.
import * as lame from '@suldashi/lame';
```

However, when the name is changed to `@suldashi/lame`, the error does not appear.